### PR TITLE
Fixes path to Terraform artifact on Windows

### DIFF
--- a/src/DotnetTerraform.Cli/DotnetTerraform.Cli.csproj
+++ b/src/DotnetTerraform.Cli/DotnetTerraform.Cli.csproj
@@ -33,7 +33,7 @@
     </Content>
     <Content Include="..\..\artifacts\windows_amd64\*">
       <Pack>true</Pack>
-      <PackagePath>tools\net6.0\any\runtimes\win10-x64\native</PackagePath>
+      <PackagePath>tools\net6.0\any\runtimes\win-x64\native</PackagePath>
     </Content>
      <Content Include="..\..\artifacts\linux_amd64\*">
       <Pack>true</Pack>


### PR DESCRIPTION
After installing the dotnet tool locally via `dotnet tool install dotnet-terraform`, running `dotnet terraform fmt --help` results in the following:

``` sh
> dotnet terraform fmt --help
An error occurred trying to start process 'C:\Users\username\.nuget\packages\dotnet-terraform\1.5.3\tools\net6.0\any\runtimes\win-x64\native\terraform.exe' with working directory 'C:\repo-path'. The system cannot find the file specified.
```

This change corrects the path to match what `Program.cs` expects.